### PR TITLE
npm ERR! Missing script: "start"

### DIFF
--- a/fullstack/.gitignore
+++ b/fullstack/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock

--- a/fullstack/package.json
+++ b/fullstack/package.json
@@ -21,7 +21,9 @@
     "jest": "^28.1.0",
     "nodemon": "^2.0.16"
   },
-  "scripts": {},
+  "scripts": {
+    "start": "node src/app.js"
+  },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
1. estava faltando script de inicialização do app, chamado no compose.
2. coloquei no package.json na parte de scripts o script que estava faltando, pois sem ele o comando para iniciar o app teria que ser outro e por boas práticas preferi manter o comando e adicionar o script.
3. agora quando rodamos docker compose up --build o app consegue iniciar e instanciar as rotas para serem utilizadas.