### PR TITLE
Error 'Not allowed by CORS' 

### DIFF
--- a/fullstack/src/app.js
+++ b/fullstack/src/app.js
@@ -5,22 +5,24 @@ const SwaggerUi = require('swagger-ui-express');
 const express = require('express');
 const { buildHandlers } = require('./modules');
 const { handlers } = buildHandlers();
-const port = Number(process.env.PORT || 8089)
+const port = Number(process.env.PORT || 8089);
 
 const app = express();
 
-const whitelist = [
-  // TODO whitelist
-]
 
-app.use(cors({
-  origin: function (origin, callback) {
-    const allowed = whitelist.indexOf(origin) !== -1
-    if (allowed) return callback(null, true);
+const whitelist = [`http://localhost:${port}`];
 
-    callback(new Error('Not allowed by CORS'))
-  }
-}))
+app.use(
+  cors(function (req, callback) {
+    const corsOptions = {
+      origin: false,
+    };
+    const allowed = whitelist.indexOf(req.header('Origin')) !== -1;
+    if (allowed) corsOptions.origin = true;
+
+    callback(null, corsOptions);
+  })
+);
 
 const swaggerConfig = {
   appRoot: __dirname,
@@ -40,5 +42,5 @@ SwaggerExpress.create(swaggerConfig, onSwaggerCreated);
 
 module.exports = {
   app,
-  ...handlers
+  ...handlers,
 };


### PR DESCRIPTION
1. A princípio pensei que o erro poderia estar na estrutura da função "origin" das opções do cors, porém mesmo reestruturando com if e else, trocando para arrow function e testando com outros valores para origin não funcionou, não entendi o porquê
2. resolvi reestruturar seguindo a documentação e tentando manter a ideia de uma whitelist com os hosts dinâmicos
3. agora conseguimos acessar as rotas da api com o middleware do cors trabalhando com hosts dinâmicos, podendo ter vários.