### PR TITLE
Error: insert into `users` ... - Table 'main.users' doesn't exist

### DIFF
--- a/fullstack/db/schema.sql
+++ b/fullstack/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
 );
 
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL

--- a/fullstack/docker-compose.yml
+++ b/fullstack/docker-compose.yml
@@ -8,14 +8,15 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: 'main'
+      MYSQL_DATABASE: main
       MYSQL_USER: admin
       MYSQL_PASSWORD: admin
+      MYSQL_ROOT_HOST: '%'
     volumes:
       - main:/var/lib/mysql
-      - ./db/:/docker-entrypoint-initdb.d/
+      - ./db/schema.sql:/docker-entrypoint-initdb.d/create_tables.sql
     ports:
-      - 3305:3305
+      - 3305:3306
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 1s
@@ -35,9 +36,9 @@ services:
         condition: service_healthy
     environment:
       WRITER_MYSQL_HOST: "mysql"
-      WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
-      WRITER_MYSQL_USER: "root"
+      WRITER_MYSQL_PASS: "admin"
+      WRITER_MYSQL_PORT: "3306"
+      WRITER_MYSQL_USER: "admin"
       NODE_ENV: "development"
       PORT: "8081"
     links:


### PR DESCRIPTION
1. db/schema.sql não estava sendo executado na criação do container do mysql
2. indiquei o caminho completo do arquivo pois assim o docker consegue identificar exatamente o arquivo que deve ser lido na inicialização do container, além disso, ajustei a tipagem da coluna 'id' da tabela 'users' para que siga a documentação.
3. agora as tabelas estão sendo criadas no momento em que o container também está sendo criado.