### PR TITLE
Criação de posts não estava retornando corretamente

### DIFF
--- a/fullstack/src/modules/handlers/Posts/createPost.js
+++ b/fullstack/src/modules/handlers/Posts/createPost.js
@@ -1,27 +1,24 @@
-'use strict'
+"use strict";
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require("http-status-codes");
 const { httpErrorHandler } = require("../../common/handlers");
-const { createPostService } = require('../../services');
+const { createPostService } = require("../../services");
 
-const createPostHandler = async(req, res, next) => {
-    try{
-        const {
-            post_text,
-            author_id
-        } = req.body
+const createPostHandler = async (req, res, next) => {
+  try {
+    const { post_text, author_id } = req.body;
 
-        const created_post = await createPostService({
-            post_text,
-            author_id
-        })
+    const created_post = await createPostService({
+      post_text,
+      author_id,
+    });
 
-        return res.status(httpStatusCodes.OK).send(created_post);
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
-}
+    return res.status(StatusCodes.CREATED).send(created_post);
+  } catch (error) {
+    return httpErrorHandler({ req, res, error });
+  }
+};
 
 module.exports = {
-    createPostHandler
-}
+  createPostHandler,
+};

--- a/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -1,37 +1,32 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
-} = require('../../../common/handlers')
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction,
+} = require("../../../common/handlers");
 
+const createPostRepositories = async ({ post } = {}) => {
+  const { transaction } = await getTransaction();
 
-const createPostRepositories = async ({
-    post
-} = {}) => {
-    const { transaction } = await getTransaction();
+  try {
+    const post_created = await transaction("posts").insert(post);
 
-    try {
-        const post_created = await transaction('posts').insert(post)
-        
-        const has_response = !Array.isArray(post_created) && post_created.length > 0;
+    const has_response = Array.isArray(post_created) && post_created.length > 0;
 
-        if (!has_response) {
-            return {
-                post_created: []
-            }
-        }
-
-
-        return {
-            post_created
-        }
-
-    } catch (err) {
-        rollbackTransaction({transaction})
-        throw new Error(err)
+    if (!has_response) {
+      return {
+        post_created: [],
+      };
     }
-}
+
+    return {
+      post_created,
+    };
+  } catch (err) {
+    rollbackTransaction({ transaction });
+    throw new Error(err);
+  }
+};
 
 module.exports = {
-    createPostRepositories
-}
+  createPostRepositories,
+};


### PR DESCRIPTION
1. expressão lógica da váriavel "has_response" na função createPostRepositories
2. retirei o operador de negação do início da expressão para que validasse se o retorno da transaction era um array, e não o contrário, já que o que de fato é retornado é um array contendo o id do recurso criado
3. agora a rota retorna o id do post criado