### PR TITLE
Deletar um post acabava por deletar todos os posts

### DIFF
--- a/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -1,25 +1,22 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
-} = require('../../../common/handlers')
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction,
+} = require("../../../common/handlers");
 
-const deletePostRepositories = async (
-    post_id
-) => {
-    const { transaction } = await getTransaction();
+const deletePostRepositories = async (post_id) => {
+  const { transaction } = await getTransaction();
 
-    try {
-        await transaction('posts').del()
+  try {
+    await transaction("posts").where({ id: post_id }).del();
 
-        await commitTransaction({transaction})
-        
-    } catch (err) {
-        rollbackTransaction({transaction})
-        throw new Error(err)
-    }
-}
+    await commitTransaction({ transaction });
+  } catch (err) {
+    rollbackTransaction({ transaction });
+    throw new Error(err);
+  }
+};
 
 module.exports = {
-    deletePostRepositories
-}
+  deletePostRepositories,
+};

--- a/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/fullstack/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -4,7 +4,7 @@ const {
   rollbackTransaction,
 } = require("../../../common/handlers");
 
-const deletePostRepositories = async (post_id) => {
+const deletePostRepositories = async ({ post_id }) => {
   const { transaction } = await getTransaction();
 
   try {

--- a/fullstack/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/fullstack/src/modules/services/Post/deletePostService/deletePostService.js
@@ -16,9 +16,9 @@ const deletePostService = async ({ post_id }) => {
 
   const [post_to_delete] = posts;
 
-  await deletePostRepositories({
-    post_id: post_to_delete.id,
-  });
+  await deletePostRepositories(
+    post_to_delete.id,
+  );
 
   return {
     deletedPost: post_to_delete,

--- a/fullstack/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/fullstack/src/modules/services/Post/deletePostService/deletePostService.js
@@ -16,9 +16,9 @@ const deletePostService = async ({ post_id }) => {
 
   const [post_to_delete] = posts;
 
-  await deletePostRepositories(
-    post_to_delete.id,
-  );
+  await deletePostRepositories({
+    post_id: post_to_delete.id,
+  });
 
   return {
     deletedPost: post_to_delete,


### PR DESCRIPTION
1. falta da função .where() no deletePostRepositories
2. sem o where a função .del() acaba deletando todos os recursos do banco, para resolver isso adicionei a função e também ajustei o argumento esperado pelo deletePostRepositories para que seja desestruturado corretamente, assim como nos outros repositórios
3. agora ao deletar um post somente aquele post é deletado, e não todos.